### PR TITLE
Provide Intermediary v2 unconditionally

### DIFF
--- a/src/main/java/org/quiltmc/Main.java
+++ b/src/main/java/org/quiltmc/Main.java
@@ -276,7 +276,9 @@ public class Main {
                 for (MavenRepository.ArtifactMetadata.Artifact artifact : intermediaries) {
                     JsonObject object = new JsonObject();
 
-                    object.addProperty("maven", artifact.mavenId());
+                    // Considering that all Intermediary versions have a Tiny v2 build as well as all
+                    // Quilt Loader versions supporting Tiny v2, it is safe to mandate the Tiny V2 build.
+                    object.addProperty("maven", artifact.mavenId() + ":v2");
                     object.addProperty("version", artifact.version);
 
                     intermediary.add(object);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -482,7 +482,7 @@ components:
       properties:
         maven:
           type: string
-          example: net.fabricmc:intermediary:1.12.2
+          example: net.fabricmc:intermediary:1.12.2:v2
           description: The maven identifier for this intermediary release.
         version:
           type: string


### PR DESCRIPTION
Do note: this sort of API change is definitely bad practice and should be avoided at any costs; except I don't want to engineer Meta v4 any time soon, so here's what we are going to do:

- Intermediary's Tiny v2 build (which is available on all versions thanks to retconning) will always be provided
- All Quilt Loader versions support them and therefore shouldn't break
- Once feasible, ~~we~~ I will (attempt to) remove Tiny v1 support from Quilt Loader

This may be reverted if breakage is caused (which hopefully won't considering all the scouting done before); This does show the need for a Meta v4 for important breaking changes though, but! I'm not a snake oil vendor *and* I have a life to worry about